### PR TITLE
 Change submodule to refactor-material-ui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "hnn_ui/geppetto"]
 	path = hnn_ui/geppetto
-	url = git@github.com:openworm/org.geppetto.frontend.git
-	branch = refactor-sync
+	url = https://github.com/openworm/org.geppetto.frontend.git
+	branch = refactor-upgrade-materialui

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,12 @@ node_js:
 env:
   global:
     secure: dn0FPQ5IG4M/3kdwnyI78ElQ308Vc3QnKAvkWfwMFb8QxDqxQdnTo7AV1qTMtbLrDNkeEWIgi4nc7jmXNtvGTwOfhAULVh6606Qs5B+ezTdwzajbbFMI8SKQx/pnTojOMu8dx7V4lMoR/YWcojR0VC1IWVC62TGbSB1k5BDGgH0=
-git:
-  submodules: false
 before_install:
   - sudo apt-get install -y xserver-xorg-dev libxext-dev libxi-dev
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive
 install:
   - git clone --quiet  https://github.com/MetaCell/geppetto-hnn.git
   - cd geppetto-hnn
-  - if [ `git branch -a | egrep "remotes/origin/${TRAVIS_BRANCH}"` ]; then git checkout $TRAVIS_BRANCH ; else echo "Branch $TRAVIS_BRANCH does not exist for the dependent bundle, checking out development ..." && git checkout development; fi
+  - if [ `git branch -a | egrep "remotes/origin/${TRAVIS_BRANCH}"` ]; then git checkout $TRAVIS_BRANCH ; else echo "Branch $TRAVIS_BRANCH does not exist for the dependent bundle, checking out material-ui-submodule ..." && git checkout material-ui-submodule; fi
   - cd ..
   - npm install --silent -g phantomjs
   - npm install --silent -g casperjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - git clone --quiet  https://github.com/MetaCell/geppetto-hnn.git
   - cd geppetto-hnn
-  - if [ `git branch -a | egrep "remotes/origin/${TRAVIS_BRANCH}"` ]; then git checkout $TRAVIS_BRANCH ; else echo "Branch $TRAVIS_BRANCH does not exist for the dependent bundle, checking out material-ui-submodule ..." && git checkout material-ui-submodule; fi
+  - if [ `git branch -a | egrep "remotes/origin/${TRAVIS_BRANCH}"` ]; then git checkout $TRAVIS_BRANCH ; else echo "Branch $TRAVIS_BRANCH does not exist for the dependent bundle, checking out development ..." && git checkout development; fi
   - cd ..
   - npm install --silent -g phantomjs
   - npm install --silent -g casperjs


### PR DESCRIPTION
As geppetto development branch was brought into the refactor-material-ui branch ([here](https://github.com/openworm/org.geppetto.frontend/commit/f2085214ac96ca59d8c3ab0e89b5c824eb78da4b)) I believe we can safely target it now as our submodule.
It also changes ssh to https as we don't need the overhead necessary to deal with the first.